### PR TITLE
Display NewsBlogConfig as column in the admin Tag list

### DIFF
--- a/aldryn_newsblog/admin/newsblog.py
+++ b/aldryn_newsblog/admin/newsblog.py
@@ -323,7 +323,7 @@ class AuthorAdmin(admin.ModelAdmin):
 
 
 class ArticleTagAdmin(TranslatableAdmin):
-    list_display = ('name',)
+    list_display = ('name', 'newsblog_config',)
     fieldsets = (
         (None, {
             'fields': (


### PR DESCRIPTION
See: http://lwlgitlab.itz.lwl.org/lwl/lwl-djangocms/-/issues/374