### PR TITLE
remove `null` from `ManyToManyField` to silence warnings on server start

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,15 @@
 Changelog
 =========
 
+2.2.3.29 (2023-01-27)
+=====================
+
+* Fix warning after model changes from 2.2.3.28
+
 2.2.3.28 (2023-01-13)
 =====================
 
 * Add write permissions limitations for users per blog section
-
 
 2.2.3.27 (2022-09-01)
 =====================

--- a/aldryn_newsblog/__init__.py
+++ b/aldryn_newsblog/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 
-__version__ = '2.2.3.28'
+__version__ = '2.2.3.29'
 
 
 default_app_config = 'aldryn_newsblog.apps.AldrynNewsBlog'

--- a/aldryn_newsblog/cms_appconfig.py
+++ b/aldryn_newsblog/cms_appconfig.py
@@ -152,7 +152,7 @@ class NewsBlogConfig(TranslatableModel, AppHookConfig):
         related_name='aldryn_newsblog_detail_footer',
     )
 
-    users = models.ManyToManyField(User, related_name='blog_sections', blank=True, null=True)
+    users = models.ManyToManyField(User, related_name='blog_sections', blank=True)
 
     @staticmethod
     def has_placeholder_change_permission(user) -> bool:

--- a/aldryn_newsblog/migrations/0028_newsblogconfig_users.py
+++ b/aldryn_newsblog/migrations/0028_newsblogconfig_users.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='newsblogconfig',
             name='users',
-            field=models.ManyToManyField(blank=True, null=True, related_name='blog_sections', to=settings.AUTH_USER_MODEL),
+            field=models.ManyToManyField(blank=True, related_name='blog_sections', to=settings.AUTH_USER_MODEL),
         ),
     ]


### PR DESCRIPTION
increment version to `2.2.3.29`
updated changelog

@nichoski Can you review & merge this please